### PR TITLE
Minor template typo fix (site_title.html)

### DIFF
--- a/themes/sapling/templates/site/site_title.html
+++ b/themes/sapling/templates/site/site_title.html
@@ -1,5 +1,5 @@
 {% block site_title %}
 {% if current_site %}
-  <h1><a href="{% url pages:frontpage %}">{{ current_site.name }}</a></h2>
+  <h1><a href="{% url pages:frontpage %}">{{ current_site.name }}</a></h1>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
There was a </h2> when there shoulda been a </h1>.

This is the smallest pull request diff EVER.
