### PR TITLE
Append build-time directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 *.swa
 *.swo
 *.pyo
+/build/
+/dist/
+/env/
+/localwiki.egg-info/
+


### PR DESCRIPTION
These directories are created while creating a dev
install (following instructions in the INSTALL file).
