### PR TITLE
Add Tag model to admin.

### DIFF
--- a/sapling/tags/admin.py
+++ b/sapling/tags/admin.py
@@ -1,0 +1,10 @@
+from django.contrib import admin
+from guardian.admin import GuardedModelAdmin
+
+from models import Tag
+
+
+class TagAdmin(GuardedModelAdmin):
+    pass
+
+admin.site.register(Tag, TagAdmin)


### PR DESCRIPTION
This allows people with staff/admin access the ability to rename a Tag.  Renaming a tag will work fine, but it won't update the PageTagSet history until page tag sets are re-saved.  I think this is fine for now?

There's no reason why we couldn't allow normal users the ability to rename tags as well.  In that case, we'll want to have them show up in RC, etc, so it's a larger feature.  We could also update the PageTagSet versions in this case.  Not sure if it's the right thing to do or not.
