### PR TITLE
Fix history crawling

### DIFF
--- a/sapling/utils/static/robots.txt
+++ b/sapling/utils/static/robots.txt
@@ -1,2 +1,8 @@
 User-agent: *
 Disallow: /*/_history/*
+
+User-agent: *
+Disallow: /*/_feed$
+
+User-agent: *
+Disallow: /*/_feed/


### PR DESCRIPTION
Needs review.

I can't figure out how to add that meta tag into the feeds right now.  But this should do the trick.  I tested this with the google webmaster tools:

```
https://scruzwiki.org/  
Allowed

https://scruzwiki.org/map/Lighthouse_Neighborhood_Park/_history/2008-07-12%2002:43:13.300000    
Blocked by line 2: Disallow: /*/_history/*

https://scruzwiki.org/map/Lighthouse_Neighborhood_Park  
Allowed

https://scruzwiki.org/Lighthouse_Neighborhood_Park_history/     
Allowed

https://scruzwiki.org/map/Lighthouse_Neighborhood_Park/_history/_feed   
Blocked by line 2: Disallow: /*/_history/*

https://scruzwiki.org/Recent_Changes/_feed/     
Blocked by line 8: Disallow: /*/_feed/

https://scruzwiki.org/Recent_Changes/_feed  
Blocked by line 5: Disallow: /*/_feed$
```
