### PR TITLE
updates default email port for smtp, port 25

### DIFF
--- a/sapling/etc/install_config/defaults/localwiki/conf/localsettings.py.template
+++ b/sapling/etc/install_config/defaults/localwiki/conf/localsettings.py.template
@@ -22,7 +22,7 @@ CLOUDMADE_API_KEY = 'CLOUDMADEAPIKEYHERE'
 # python -m smtpd -n -c DebuggingServer localhost:1025
 EMAIL_HOST = 'localhost'
 EMAIL_HOST_PASSWORD = ''
-EMAIL_PORT = 1025
+EMAIL_PORT = 25
 EMAIL_USE_TLS = False
 
 #######################################################################


### PR DESCRIPTION
We had some issues configuring postfix / sendmail out-of-the-box, realized we had overlooked this config, which uses 1025 as the default instead of the SMTP port 25. Will be valuable in the future to stick with 25.
