### PR TITLE
Allow width, height in styles on iframes.

### DIFF
--- a/sapling/pages/plugins.py
+++ b/sapling/pages/plugins.py
@@ -355,7 +355,8 @@ class EmbedCodeNode(Node):
     # We allow the iframe tag in embeds.
     allowed_tags.append('iframe')
     allowed_attributes['iframe'] = [
-        'allowfullscreen', 'width', 'height', 'src']
+        'allowfullscreen', 'width', 'height', 'src', 'style']
+    allowed_styles_map['iframe'] = ['width', 'height']
 
     def __init__(self, nodelist):
         self.nodelist = nodelist


### PR DESCRIPTION
Many iframes contain width and height as a style. We're already allowing width, height as an attribute, so this makes sense.
