### PR TITLE
Allow hardcoded settings to be overridden by environment variables

### DIFF
--- a/sapling/manage.py
+++ b/sapling/manage.py
@@ -5,8 +5,10 @@ import sys
 
 # We have to hard-code these here, as we run a few setup commands (in
 # setup_all) that execute before the settings can be safely loaded.
-DATA_ROOT = os.path.join(sys.prefix, 'share', 'localwiki')
-PROJECT_ROOT = os.path.split(os.path.abspath(__file__))[0]
+DATA_ROOT = os.environ.get('LOCALWIKI_DATA_ROOT') or \
+    os.path.join(sys.prefix, 'share', 'localwiki')
+PROJECT_ROOT = os.environ.get('LOCALWIKI_PROJECT_ROOT') or \
+    os.path.split(os.path.abspath(__file__))[0]
 
 # Add virtualenv packages
 site_packages = os.path.join(DATA_ROOT, 'env', 'lib',

--- a/sapling/settings.py
+++ b/sapling/settings.py
@@ -16,8 +16,10 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-DATA_ROOT = os.path.join(sys.prefix, 'share', 'localwiki')
-PROJECT_ROOT = os.path.join(os.path.dirname(__file__))
+DATA_ROOT = os.environ.get('LOCALWIKI_DATA_ROOT') or \
+    os.path.join(sys.prefix, 'share', 'localwiki')
+PROJECT_ROOT = os.environ.get('LOCALWIKI_PROJECT_ROOT') or \
+    os.path.split(os.path.abspath(__file__))[0]
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Writing and reading data from a directory (`DATA_ROOT`) based on where python data files are feels weird, and is impossible to change unless one is comfortable monkey-patching `sys.prefix`. This keeps the same default setting, but allows it to be overridden by an environment variable. For good measure, `PROJECT_ROOT` received the same treatment.
