### PR TITLE
Management command 'set_email' to set existing user's email address

### DIFF
--- a/sapling/users/management/commands/set_email.py
+++ b/sapling/users/management/commands/set_email.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
+from django.db.utils import IntegrityError
+from django.contrib.auth.models import User
+
+
+class Command(BaseCommand):
+    help = 'Sets the email address of the specified username.'
+
+    def handle(self, user_name=None, email_address="", **options):
+        if user_name is None:
+            raise CommandError("You must provide a username.")
+
+        try:
+            uname = User.objects.get(username=user_name)
+        except User.DoesNotExist:
+            raise CommandError('Username "%s" does not exist/' % user_name)
+        
+        uname.email = email_address
+        
+        try:
+            uname.save()
+        except IntegrityError:
+            raise CommandError('That password is already in use by another '+
+                               'user. You must specify a unique password.')
+        
+        self.stdout.write('Successfully set email address for "%s" to "%s".\n' % (
+                              user_name, email_address))


### PR DESCRIPTION
This is just the set_email management command. It does not include the send password reset email option.
