### PR TITLE
Set email management command

### DIFF
--- a/sapling/users/management/commands/set_email.py
+++ b/sapling/users/management/commands/set_email.py
@@ -5,8 +5,8 @@ from django.contrib.auth.models import User
 
 
 class Command(BaseCommand):
-    help = 'Sets the email address of the specified username.\n'+
-           'Usage: localwiki-manage set_email <username> <email address>'
+    help = ('Sets the email address of the specified username.\n'+
+           'Usage: localwiki-manage set_email <username> <email address>')
 
     def handle(self, user_name=None, email_address="", **options):
         if user_name is None:
@@ -15,7 +15,7 @@ class Command(BaseCommand):
         try:
             uname = User.objects.get(username=user_name)
         except User.DoesNotExist:
-            raise CommandError('Username "%s" does not exist/' % user_name)
+            raise CommandError('Username "%s" does not exist.' % user_name)
         
         uname.email = email_address
         
@@ -24,7 +24,7 @@ class Command(BaseCommand):
         except IntegrityError:
             raise CommandError('That email address is already in use by '+
                                'another user. You must specify a unique '+
-                               'password.')
+                               'email address.')
         
         self.stdout.write('Successfully set email address for "%s" to "%s".\n' % (
                               user_name, email_address))


### PR DESCRIPTION
This is the set_email management command without the send password reset email option. It includes requested usage example and other fixes to the original pull request.
