### PR TITLE
fix #246 - show tags links with solid underline

### DIFF
--- a/sapling/pages/plugins.py
+++ b/sapling/pages/plugins.py
@@ -326,6 +326,8 @@ class LinkNode(Node):
                         cls = ' class="file_%s"' % file.rough_type
                     except PageFile.DoesNotExist:
                         cls = ' class="missing_link"'
+                elif unquote_plus(url).startswith('tags/'):
+                    cls = ' class="tag_link"'
                 else:
                     try:
                         page = Page.objects.get(slug__exact=slugify(url))

--- a/sapling/themes/sapling/assets/pages/css/pages.css
+++ b/sapling/themes/sapling/assets/pages/css/pages.css
@@ -3,6 +3,11 @@
     border-bottom: 1px dashed;
 }
 
+.tag_link {
+    background: url(../../img/tag-icon-small.png) top left no-repeat;
+    padding-left: 22px;
+}
+
 /* File icons */
 .no_icon {
    background: inherit !important;


### PR DESCRIPTION
and a tag indicator box
