### PR TITLE
restore full pages by default for page endpoint

### DIFF
--- a/sapling/pages/api.py
+++ b/sapling/pages/api.py
@@ -168,7 +168,8 @@ class PageResource(PageURLMixin, ModelResource):
         return self.create_response(request, object_list)
 
     def dehydrate(self, bundle):
-        if not bundle.request.GET.get('full'):
+        if (not bundle.request.META['PATH_INFO'].startswith('/api/page') and
+            not bundle.request.GET.get('full')):
             bundle = bundle.data['resource_uri']
         return bundle
 


### PR DESCRIPTION
#459 accidentally changed the pages endpoint to only show uri's by default.
