### PR TITLE
fixes #447 - drop trailing slash from fetch docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -90,7 +90,7 @@ Fetch
 
 ::
 
-    /api/site/[id]/
+    /api/site/[id]
 
 
 Users
@@ -130,7 +130,7 @@ Fetch
 
 ::
 
-    /api/user/[id]/
+    /api/user/[id]
 
 
 
@@ -239,7 +239,7 @@ Fetch
 
 ::
 
-    /api/file/[id]/
+    /api/file/[id]
 
 Create
 ~~~~~~
@@ -413,7 +413,7 @@ Fetch
 
 ::
 
-    /api/tag/[slug]/
+    /api/tag/[slug]
 
 Create
 ~~~~~~


### PR DESCRIPTION
Sure enough, the [default tastypie base_urls](https://github.com/toastdriven/django-tastypie/blob/master/tastypie/resources.py#L311-320) allow the detail uri to contain `/` and `-` characters. So, `/api/tag/foo/` goes to `dispatch_detail` with resource_name: `tag` and slug: `foo/`

So, I think the best thing to do is to adopt a convention of not _officially_ supporting trailing slashes for the detail nor set endpoints.
