### PR TITLE
fixes #470 - smarter page api context logic

### DIFF
--- a/sapling/pages/api.py
+++ b/sapling/pages/api.py
@@ -170,8 +170,11 @@ class PageResource(PageURLMixin, ModelResource):
         return self.create_response(request, object_list)
 
     def dehydrate(self, bundle):
-        if (not bundle.request.META['PATH_INFO'].startswith('/api/page') and
-            not bundle.request.GET.get('full')):
+        in_page_api = False
+        for pattern in self.urls:
+            if pattern.resolve(bundle.request.path.replace('/api/', '')):
+                in_page_api = True
+        if (not in_page_api and not bundle.request.GET.get('full')):
             bundle = bundle.data['resource_uri']
         return bundle
 


### PR DESCRIPTION
I'm not totally happy with this, but it's smarter about the `page` portion of the identifier; I can't find a good way to dynamically match the leading `api` portion without hard-coding it. :/
