### PR TITLE
remove stray apple-icon link from javascript snippet

### DIFF
--- a/sapling/themes/sapling/templates/site/base.html
+++ b/sapling/themes/sapling/templates/site/base.html
@@ -36,7 +36,6 @@
       ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
       var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
     })();
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   </script>
   {% endif %}
   {% endblock %}


### PR DESCRIPTION
remove stray <link> tag from within Google Analytics setup; problem with this seen on Arborwiki
