### PR TITLE
typo fix "cloudemade" -> "cloudmade" in prompt

### DIFF
--- a/sapling/utils/management/commands/init_settings.py
+++ b/sapling/utils/management/commands/init_settings.py
@@ -12,7 +12,7 @@ class Command(object):
                               action='store_true',
                               dest='skip_cloudmade_key',
                               default=False,
-                              help="Skip prompt for Cloudemade API key"
+                              help="Skip prompt for Cloudmade API key"
                              )
 
     def _write_settings(self, vals):


### PR DESCRIPTION
minor fix to prompt which spelled "cloudmade" wrong
