### PR TITLE
fix KeyError at localwiki-manage setup

### DIFF
--- a/sapling/manage.py
+++ b/sapling/manage.py
@@ -31,6 +31,8 @@ def main(set_apps_path=True):
         init_options = {}
         if '--skip-cloudmade-key' in options:
             init_options = {'skip_cloudmade_key': True,}
+        else:
+            init_options = {'skip_cloudmade_key': False,}
         if sys.argv[1] == 'setup_all':
             # We have to special-case this commands, it happens before the
             # install's localsettings.py is installed, so the usual django


### PR DESCRIPTION
I get KeyError when I run localwiki-manage setup_all.

``` shell
(env)taro@test:/srv/deploy/lw006$ localwiki-manage setup_all
...
Get a Cloudmade API Key.
1. Go to http://cloudmade.com/register
2. After you've signed in, click "Get an API Key". Fill out the form (details don't matter)
3. Paste the API key below:
Traceback (most recent call last):
  File "/srv/deploy/lw006/env/bin/localwiki-manage", line 9, in <module>
    load_entry_point('localwiki==0.5.4', 'console_scripts', 'localwiki-manage')()
  File "/srv/deploy/lw006/env/local/lib/python2.7/site-packages/localwiki-0.5.4-py2.7.egg/sapling/manage.py", line 45, in main
    **init_options)
  File "/srv/deploy/lw006/env/local/lib/python2.7/site-packages/localwiki-0.5.4-py2.7.egg/sapling/utils/management/commands/init_settings.py", line 60, in run
    c.handle(**options)
  File "/srv/deploy/lw006/env/local/lib/python2.7/site-packages/localwiki-0.5.4-py2.7.egg/sapling/utils/management/commands/init_settings.py", line 45, in handle
    if not options['skip_cloudmade_key']:
KeyError: 'skip_cloudmade_key'
```

I fix it.
